### PR TITLE
fix(actions.toggle): ensure checking for time machine buf for proper toggling

### DIFF
--- a/lua/time-machine/actions.lua
+++ b/lua/time-machine/actions.lua
@@ -11,6 +11,12 @@ local M = {}
 function M.toggle()
 	local cur_bufnr = vim.api.nvim_get_current_buf()
 
+	--- if the current buffer is a time machine buffer, close it
+	if utils.is_time_machine_active(cur_bufnr) then
+		utils.close_buf(cur_bufnr)
+		return
+	end
+
 	-- Skip unnamed buffers
 	if vim.api.nvim_buf_get_name(cur_bufnr) == "" then
 		vim.notify(
@@ -26,12 +32,6 @@ function M.toggle()
 			"Current buffer is not listed, cannot show undotree",
 			vim.log.levels.WARN
 		)
-		return
-	end
-
-	--- if the current buffer is a time machine buffer, close it
-	if utils.is_time_machine_active(cur_bufnr) then
-		utils.close_buf(cur_bufnr)
 		return
 	end
 


### PR DESCRIPTION
This change move the `is_time_machine_active` check higher up to ensure
we are not getting early return for unnamed or unlisted buffer issue,
which prevents the toggle off function
