### PR TITLE
fix(ui): send event `undo` and `redo` instead of manual refresh the UI

### DIFF
--- a/lua/time-machine/constants.lua
+++ b/lua/time-machine/constants.lua
@@ -7,6 +7,8 @@ M.constants = {
 	ns = vim.api.nvim_create_namespace("time-machine"),
 	events = {
 		undo_created = "TimeMachineUndoCreated",
+		undo_called = "TimeMachineUndoCalled",
+		redo_called = "TimeMachineRedoCalled",
 		undo_restored = "TimeMachineUndoRestored",
 		undofile_deleted = "TimeMachineUndofileDeleted",
 	},

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -455,7 +455,10 @@ function M.show_tree(ut, content_bufnr)
 		callback = function()
 			vim.api.nvim_buf_call(content_bufnr, function()
 				vim.cmd("undo")
-				M.refresh(time_machine_bufnr, seq_map, content_bufnr)
+				vim.api.nvim_exec_autocmds(
+					"User",
+					{ pattern = constants.events.undo_called }
+				)
 			end)
 		end,
 	})
@@ -467,7 +470,10 @@ function M.show_tree(ut, content_bufnr)
 		callback = function()
 			vim.api.nvim_buf_call(content_bufnr, function()
 				vim.cmd("redo")
-				M.refresh(time_machine_bufnr, seq_map, content_bufnr)
+				vim.api.nvim_exec_autocmds(
+					"User",
+					{ pattern = constants.events.redo_called }
+				)
 			end)
 		end,
 	})
@@ -528,6 +534,8 @@ function M.show_tree(ut, content_bufnr)
 		pattern = {
 			constants.events.undo_created,
 			constants.events.undo_restored,
+			constants.events.undo_called,
+			constants.events.redo_called,
 		},
 		callback = function()
 			-- only refresh if that buffer is still open


### PR DESCRIPTION
We have already set up the UI refresh autocmd, and we can use that.
