### PR TITLE
fix(actions.toggle): do not notify if condition not met for toggling

### DIFF
--- a/lua/time-machine/actions.lua
+++ b/lua/time-machine/actions.lua
@@ -19,19 +19,11 @@ function M.toggle()
 
 	-- Skip unnamed buffers
 	if vim.api.nvim_buf_get_name(cur_bufnr) == "" then
-		vim.notify(
-			"Current buffer has no name, cannot show undotree",
-			vim.log.levels.WARN
-		)
 		return
 	end
 
 	-- Skip unlisted buffers
 	if not vim.api.nvim_get_option_value("buflisted", { buf = cur_bufnr }) then
-		vim.notify(
-			"Current buffer is not listed, cannot show undotree",
-			vim.log.levels.WARN
-		)
 		return
 	end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed warning notifications that appeared when attempting to use the feature on unnamed or unlisted buffers. The feature now silently exits in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->