### PR TITLE
fix(config.setup_autocmds): ignore time machine buffer for emitting `undo_created` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ See the example below for how to configure **time-machine.nvim** with keybinding
   "TimeMachineToggle",
   "TimeMachinePurgeBuffer",
   "TimeMachinePurgeAll",
+  "TimeMachineLogShow",
+  "TimeMachineLogClear",
  },
  ---@type TimeMachine.Config
  opts = {},
@@ -223,6 +225,11 @@ See the example below for how to configure **time-machine.nvim** with keybinding
    "<leader>tX",
    "<cmd>TimeMachinePurgeAll<cr>",
    desc = "[Time Machine] Purge all",
+  },
+  {
+   "<leader>tl",
+   "<cmd>TimeMachineLogShow<cr>",
+   desc = "[Time Machine] Show log",
   },
  },
 },

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -1,4 +1,4 @@
-*time-machine.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 April 27
+*time-machine.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 April 28
 
 ==============================================================================
 Table of Contents                        *time-machine.nvim-table-of-contents*

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -207,6 +207,8 @@ keybindings.
       "TimeMachineToggle",
       "TimeMachinePurgeBuffer",
       "TimeMachinePurgeAll",
+      "TimeMachineLogShow",
+      "TimeMachineLogClear",
      },
      ---@type TimeMachine.Config
      opts = {},
@@ -230,6 +232,11 @@ keybindings.
        "<leader>tX",
        "<cmd>TimeMachinePurgeAll<cr>",
        desc = "[Time Machine] Purge all",
+      },
+      {
+       "<leader>tl",
+       "<cmd>TimeMachineLogShow<cr>",
+       desc = "[Time Machine] Show log",
       },
      },
     },

--- a/lua/time-machine/config.lua
+++ b/lua/time-machine/config.lua
@@ -98,7 +98,10 @@ function M.setup_autocmds()
 		{ "BufWritePost", "TextChanged", "InsertLeave" },
 		{
 			group = utils.augroup("undopoint_created"),
-			callback = function()
+			callback = function(ev)
+				if utils.is_time_machine_active(ev.buf) then
+					return
+				end
 				vim.api.nvim_exec_autocmds(
 					"User",
 					{ pattern = constants.events.undo_created }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary undo event triggers when the time machine is already active on a buffer, ensuring smoother and more predictable behavior.

- **New Features**
  - Added new commands to show and clear the time machine log.
  - Introduced a keybinding `<leader>tl` to quickly access the time machine log display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->