### PR TITLE
fix(utils): allow optional bufnr and winid to close it

### DIFF
--- a/lua/time-machine/utils.lua
+++ b/lua/time-machine/utils.lua
@@ -115,19 +115,19 @@ function M.merge_lists(default, user)
 end
 
 --- Close a buffer
----@param bufnr integer The buffer number
+---@param bufnr? integer The buffer number
 ---@return nil
 function M.close_buf(bufnr)
-	if vim.api.nvim_buf_is_valid(bufnr) then
+	if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
 		vim.api.nvim_buf_delete(bufnr, { force = true })
 	end
 end
 
 --- Close a window
----@param win integer The window number
+---@param win? integer The window number
 ---@return nil
 function M.close_win(win)
-	if vim.api.nvim_win_is_valid(win) then
+	if win and vim.api.nvim_win_is_valid(win) then
 		vim.api.nvim_win_close(win, true)
 	end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when closing buffers or windows by ensuring the operations are skipped if no target is specified, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->