### PR TITLE
fix(ui): avoid reusing existing floats

### DIFF
--- a/lua/time-machine/diff.lua
+++ b/lua/time-machine/diff.lua
@@ -60,20 +60,21 @@ function M.preview_diff_native(old_lines, new_lines)
 
 	local keymaps = require("time-machine.config").config.keymaps or {}
 
+	local win = require("time-machine.window").create_native_float_win(
+		preview_buf,
+		"Preview (Native)"
+	)
+
 	vim.api.nvim_buf_set_keymap(preview_buf, "n", keymaps.close, "", {
 		nowait = true,
 		noremap = true,
 		silent = true,
 		callback = function()
 			logger.info("Closing native preview buffer %d", preview_buf)
-			require("time-machine.utils").close_buf(preview_buf)
+			require("time-machine.utils").close_win(win)
 		end,
 	})
 
-	require("time-machine.window").create_native_float_win(
-		preview_buf,
-		"Preview (Native)"
-	)
 	logger.info("Displayed native diff preview")
 end
 

--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -2,8 +2,6 @@ local logger = require("time-machine.logger")
 
 local M = {}
 
-local native_float = nil
-
 local winborder = vim.api.nvim_get_option_value(
 	"winborder",
 	{ scope = "local" }
@@ -19,18 +17,6 @@ function M.create_native_float_win(bufnr, title)
 		bufnr,
 		tostring(title)
 	)
-
-	if native_float then
-		logger.info(
-			"Reusing existing float window %d for buffer %d",
-			native_float,
-			bufnr
-		)
-		if vim.api.nvim_win_is_valid(native_float) then
-			vim.api.nvim_win_set_buf(native_float, bufnr)
-			return
-		end
-	end
 
 	local config_float_opts = require("time-machine.config").config.float_opts
 		or {}
@@ -59,7 +45,6 @@ function M.create_native_float_win(bufnr, title)
 		return
 	end
 
-	native_float = win
 	logger.info("Opened native float window %d (buf=%d)", win, bufnr)
 
 	return win


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved window management throughout the UI to consistently close floating and split windows instead of just closing buffers.
  - Removed redundant window creation and simplified the logic for displaying and closing UI elements.
  - Unified the handling of window references for more reliable and predictable user interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->