### PR TITLE
fix(window.create_native_split_win): eliminate orphaned empty buffer when creating split

### DIFF
--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -68,8 +68,6 @@ function M.create_native_split_win(bufnr)
 
 	local win = vim.api.nvim_get_current_win()
 
-	vim.api.nvim_win_set_buf(win, bufnr)
-
 	vim.api.nvim_win_set_width(win, width)
 
 	vim.api.nvim_set_option_value(

--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -50,7 +50,7 @@ function M.create_native_float_win(bufnr, title)
 	return win
 end
 
---- Create a floating window for native
+--- Create a split window for native
 ---@param bufnr integer The buffer to open
 ---@return integer|nil win_id The window handle
 function M.create_native_split_win(bufnr)
@@ -61,13 +61,10 @@ function M.create_native_split_win(bufnr)
 
 	local width = config_split_opts.width or 50
 
-	if config_split_opts.split == "left" then
-		vim.cmd("topleft vnew")
-		logger.info("Opening split on left for buffer %d", bufnr)
-	else
-		vim.cmd("botright vnew")
-		logger.info("Opening split on right for buffer %d", bufnr)
-	end
+	local side = config_split_opts.split == "left" and "topleft" or "botright"
+
+	vim.cmd(string.format("%s vertical sbuffer %d", side, bufnr))
+	logger.info("Opening split on %s for buffer %d", side, bufnr)
 
 	local win = vim.api.nvim_get_current_win()
 

--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -63,6 +63,11 @@ function M.create_native_split_win(bufnr)
 
 	local side = config_split_opts.split == "left" and "topleft" or "botright"
 
+	if not vim.api.nvim_buf_is_valid(bufnr) then
+		logger.error("Invalid buffer %d", bufnr)
+		return
+	end
+
 	vim.cmd(string.format("%s vertical sbuffer %d", side, bufnr))
 	logger.info("Opening split on %s for buffer %d", side, bufnr)
 


### PR DESCRIPTION
Fixes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the way vertical split windows open buffers, improving stability and error handling without changing the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->