### PR TITLE
feat(window): add configurable `winblend` for floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ vim.opt.undodir = vim.fn.expand("~/.undodir") -- Set custom undo directory
  float_opts = {
   width = 0.8, -- between 0 and 1
   height = 0.8, -- between 0 and 1
+  winblend = 0,
  },
  diff_tool = "native", -- default diff engine
  native_diff_opts = { -- only used when diff_tool is "native"
@@ -186,6 +187,7 @@ vim.opt.undodir = vim.fn.expand("~/.undodir") -- Set custom undo directory
 ---@class TimeMachine.Config.FloatOpts
 ---@field width? integer The width of the window
 ---@field height? integer The height of the window
+---@field winblend? integer The winblend of the window
 ```
 
 ## 🚀 Quick Start

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -113,6 +113,7 @@ DEFAULT OPTIONS ~
      float_opts = {
       width = 0.8, -- between 0 and 1
       height = 0.8, -- between 0 and 1
+      winblend = 0,
      },
      diff_tool = "native", -- default diff engine
      native_diff_opts = { -- only used when diff_tool is "native"
@@ -191,6 +192,7 @@ TYPE DEFINITIONS ~
     ---@class TimeMachine.Config.FloatOpts
     ---@field width? integer The width of the window
     ---@field height? integer The height of the window
+    ---@field winblend? integer The winblend of the window
 <
 
 

--- a/lua/time-machine/config.lua
+++ b/lua/time-machine/config.lua
@@ -15,6 +15,7 @@ local defaults = {
 	float_opts = {
 		width = 0.8,
 		height = 0.8,
+		winblend = 0,
 	},
 	diff_tool = "native",
 	native_diff_opts = {

--- a/lua/time-machine/types.lua
+++ b/lua/time-machine/types.lua
@@ -33,6 +33,7 @@
 ---@class TimeMachine.Config.FloatOpts
 ---@field width? integer The width of the window
 ---@field height? integer The height of the window
+---@field winblend? integer The winblend of the window
 
 ---@class TimeMachine.SeqMapRaw
 ---@field entry vim.fn.undotree.entry The undotree entry

--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -45,6 +45,12 @@ function M.create_native_float_win(bufnr, title)
 		return
 	end
 
+	vim.api.nvim_set_option_value(
+		"winblend",
+		config_float_opts.winblend or 0,
+		{ scope = "local", win = win }
+	)
+
 	logger.info("Opened native float window %d (buf=%d)", win, bufnr)
 
 	return win


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional configuration setting to control the transparency of floating windows via the `winblend` option.
- **Documentation**
  - Updated documentation to describe the new `winblend` transparency setting and its usage in configuration examples and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->