### PR TITLE
fix(window.create_native_float_win): ensure grabbing footer text keymap from config

### DIFF
--- a/lua/time-machine/window.lua
+++ b/lua/time-machine/window.lua
@@ -21,6 +21,11 @@ function M.create_native_float_win(bufnr, title)
 	local config_float_opts = require("time-machine.config").config.float_opts
 		or {}
 
+	local keymaps = require("time-machine.config").config.keymaps or {}
+
+	local footer_text =
+		string.format("Press `%s` to exit", keymaps.close or "q")
+
 	---@type vim.api.keyset.win_config
 	local win_opts = {
 		relative = "editor",
@@ -29,7 +34,7 @@ function M.create_native_float_win(bufnr, title)
 		height = config_float_opts.height or 0.8,
 		title = "Time Machine" .. (title and (" - " .. title) or ""),
 		title_pos = "center",
-		footer = "Press `q` to exit",
+		footer = footer_text,
 		footer_pos = "center",
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - The footer in the floating window now displays the actual configured keybinding for closing, instead of always showing "Press `q` to exit". If no custom keybinding is set, it will still default to "q".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->