### PR TITLE
feat(highlights): add `timeline_alt` for highlight overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ vim.api.nvim_create_autocmd("User", {
 
 - `TimeMachineCurrent` - Current sequence (current line)
 - `TimeMachineTimeline` - Current active timeline (for the icon)
+- `TimeMachineTimelineAlt` - Non active timeline (for the icon)
 - `TimeMachineKeymap` - Keymaps at the header section
 - `TimeMachineInfo` - Info at the header section
 - `TimeMachineSeq` - Individual sequence number
@@ -426,6 +427,7 @@ vim.api.nvim_set_hl(0, "TimeMachineCurrent", { fg = "#7dcfff", bold = true })
   local highlights = {
    TimeMachineCurrent = { bg = colors.blue, fg = colors.base, style = { "bold" } },
    TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
+   TimeMachineTimelineAlt = { fg = colors.overlay2 },
    TimeMachineKeymap = { fg = colors.teal, style = { "italic" } },
    TimeMachineInfo = { fg = colors.subtext0, style = { "italic" } },
    TimeMachineSeq = { fg = colors.peach, style = { "bold" } },

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -444,6 +444,7 @@ HLGROUPS                        *time-machine.nvim-time-machine.nvim-hlgroups*
 
 - `TimeMachineCurrent` - Current sequence (current line)
 - `TimeMachineTimeline` - Current active timeline (for the icon)
+- `TimeMachineTimelineAlt` - Non active timeline (for the icon)
 - `TimeMachineKeymap` - Keymaps at the header section
 - `TimeMachineInfo` - Info at the header section
 - `TimeMachineSeq` - Individual sequence number
@@ -472,6 +473,7 @@ CATPPUCCIN INTEGRATION (AUTHOR CONFIG) ~
       local highlights = {
        TimeMachineCurrent = { bg = colors.blue, fg = colors.base, style = { "bold" } },
        TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
+       TimeMachineTimelineAlt = { fg = colors.overlay2 },
        TimeMachineKeymap = { fg = colors.teal, style = { "italic" } },
        TimeMachineInfo = { fg = colors.subtext0, style = { "italic" } },
        TimeMachineSeq = { fg = colors.peach, style = { "bold" } },

--- a/lua/time-machine/config.lua
+++ b/lua/time-machine/config.lua
@@ -59,6 +59,7 @@ function M.setup_highlights()
 	local defaults_colors = {
 		current = { bg = "#3c3836", fg = "#fabd2f", bold = true },
 		timeline = { fg = "#fabd2f", bold = true },
+		timeline_alt = { fg = "#939AB7" },
 		keymap = { fg = "#8bd5ca", italic = true },
 		info = { fg = "#939AB7", italic = true },
 		seq = { fg = "#ed8796", bold = true },

--- a/lua/time-machine/constants.lua
+++ b/lua/time-machine/constants.lua
@@ -16,6 +16,7 @@ M.constants = {
 	hl = {
 		current = "TimeMachineCurrent",
 		timeline = "TimeMachineTimeline",
+		timeline_alt = "TimeMachineTimelineAlt",
 		keymap = "TimeMachineKeymap",
 		info = "TimeMachineInfo",
 		seq = "TimeMachineSeq",

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -122,6 +122,35 @@ local function set_highlights(bufnr, seq_map, curr_seq, lines)
 				})
 			end
 
+			--- get after first character until the first bracket (alt timeline)
+			local first_bracket_start = line:find("%[", 1, false)
+			if first_bracket_start then
+				if first_bracket_start and #line > 1 then
+					local between_start = 2 -- after the first character
+					local between_end = first_bracket_start - 1
+					local between_str = line:sub(between_start, between_end)
+
+					local trimmed = between_str:match("^%s*(.-)%s*$")
+					local leading_spaces = #between_str:match("^(%s*)")
+
+					local start_col = between_start - 1 + leading_spaces
+					local end_col = start_col + #trimmed
+
+					if #trimmed > 0 then
+						vim.api.nvim_buf_set_extmark(
+							bufnr,
+							ns,
+							row,
+							start_col,
+							{
+								end_col = end_col,
+								hl_group = hl.timeline_alt,
+							}
+						)
+					end
+				end
+			end
+
 			--- match the sequence number
 			for seq in str_gmatch(line, "%b[]") do
 				local start_col = str_find(line, seq, 1, true) - 1

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -124,30 +124,22 @@ local function set_highlights(bufnr, seq_map, curr_seq, lines)
 
 			--- get after first character until the first bracket (alt timeline)
 			local first_bracket_start = line:find("%[", 1, false)
-			if first_bracket_start then
-				if first_bracket_start and #line > 1 then
-					local between_start = 2 -- after the first character
-					local between_end = first_bracket_start - 1
-					local between_str = line:sub(between_start, between_end)
+			if first_bracket_start and #line > 1 then
+				local between_start = 2 -- after the first character
+				local between_end = first_bracket_start - 1
+				local between_str = line:sub(between_start, between_end)
 
-					local trimmed = between_str:match("^%s*(.-)%s*$")
-					local leading_spaces = #between_str:match("^(%s*)")
+				local trimmed = between_str:match("^%s*(.-)%s*$")
+				local leading_spaces = #between_str:match("^(%s*)")
 
-					local start_col = between_start - 1 + leading_spaces
-					local end_col = start_col + #trimmed
+				local start_col = between_start - 1 + leading_spaces
+				local end_col = start_col + #trimmed
 
-					if #trimmed > 0 then
-						vim.api.nvim_buf_set_extmark(
-							bufnr,
-							ns,
-							row,
-							start_col,
-							{
-								end_col = end_col,
-								hl_group = hl.timeline_alt,
-							}
-						)
-					end
+				if #trimmed > 0 then
+					vim.api.nvim_buf_set_extmark(bufnr, ns, row, start_col, {
+						end_col = end_col,
+						hl_group = hl.timeline_alt,
+					})
 				end
 			end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new highlight group for non-active timeline icons, providing clearer visual distinction in the timeline UI.
- **Documentation**
  - Updated user documentation and theme integration examples to include the new highlight group and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->