### PR TITLE
chore(readme): update latest catppuccin style

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,15 @@ vim.api.nvim_set_hl(0, "TimeMachineCurrent", { fg = "#7dcfff", bold = true })
  opts = function(_, opts)
   local colors = require("catppuccin.palettes").get_palette()
 
+  local c_utils = require("catppuccin.utils.colors")
+
+  ---@type {[string]: CtpHighlight}
   local highlights = {
-   TimeMachineCurrent = { bg = colors.blue, fg = colors.base, style = { "bold" } },
+   TimeMachineCurrent = {
+    bg = c_utils.darken(colors.blue, 0.18, colors.base),
+    fg = colors.blue,
+    style = { "bold" },
+   },
    TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
    TimeMachineTimelineAlt = { fg = colors.overlay2 },
    TimeMachineKeymap = { fg = colors.teal, style = { "italic" } },

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -470,8 +470,15 @@ CATPPUCCIN INTEGRATION (AUTHOR CONFIG) ~
      opts = function(_, opts)
       local colors = require("catppuccin.palettes").get_palette()
     
+      local c_utils = require("catppuccin.utils.colors")
+    
+      ---@type {[string]: CtpHighlight}
       local highlights = {
-       TimeMachineCurrent = { bg = colors.blue, fg = colors.base, style = { "bold" } },
+       TimeMachineCurrent = {
+        bg = c_utils.darken(colors.blue, 0.18, colors.base),
+        fg = colors.blue,
+        style = { "bold" },
+       },
        TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
        TimeMachineTimelineAlt = { fg = colors.overlay2 },
        TimeMachineKeymap = { fg = colors.teal, style = { "italic" } },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the appearance of the Catppuccin color scheme integration for the TimeMachineCurrent highlight group by adjusting background and foreground colors for better visual distinction.

- **Documentation**
  - Updated documentation to reflect the new color scheme changes for the TimeMachineCurrent highlight group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->