### PR TITLE
fix(ui): add padding before first icon node in timeline

### DIFF
--- a/lua/time-machine/tree.lua
+++ b/lua/time-machine/tree.lua
@@ -126,8 +126,11 @@ function M.build_tree_lines(ut, seq_map, tags, show_current_timeline_only)
 					line[c + 1] =
 						string.format("%s ", constants.icons.tree_vertical_last)
 				else
-					line[c + 1] =
-						string.format("%s ", constants.icons.tree_vertical_join)
+					line[c + 1] = string.format(
+						"%s%s",
+						constants.icons.tree_vertical_join,
+						constants.icons.tree_horizontal
+					)
 				end
 			else
 				line[c + 1] = verticals[c]
@@ -138,7 +141,7 @@ function M.build_tree_lines(ut, seq_map, tags, show_current_timeline_only)
 			--- force current timeline to have separator always (1st column)
 			if c == 0 then
 				line[c + 1] =
-					string.format("%s ", constants.icons.tree_vertical)
+					string.format(" %s ", constants.icons.tree_vertical)
 			end
 		end
 
@@ -146,8 +149,17 @@ function M.build_tree_lines(ut, seq_map, tags, show_current_timeline_only)
 		line[col + 1] = (
 			entry.save
 			and entry.save > 0
-			and string.format("%s ", constants.icons.saved)
-		) or string.format("%s ", constants.icons.point)
+			and string.format(
+				"%s%s ",
+				col == 0 and " " or "",
+				constants.icons.saved
+			)
+		)
+			or string.format(
+				"%s%s ",
+				col == 0 and " " or "",
+				constants.icons.point
+			)
 
 		verticals[col] = true
 

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -8,7 +8,7 @@ local logger = require("time-machine.logger")
 
 local M = {}
 
-local current_timeline_annotation = "╭─ Current timeline"
+local current_timeline_annotation = " ╭─ Current timeline"
 local is_current_timeline_toggled = false
 local ns = constants.ns
 local hl = constants.hl
@@ -113,7 +113,7 @@ local function set_highlights(bufnr, seq_map, curr_seq, lines)
 		--- is within sequence
 		if type(id) == "number" and id ~= curr_seq then
 			--- get the first character (current timeline)
-			local first_char = line:sub(1, 1)
+			local first_char = line:sub(1 * 2, 1 * 2)
 			if first_char and first_char ~= "" then
 				local start_col = str_find(line, first_char, 1, true) - 1
 				vim.api.nvim_buf_set_extmark(bufnr, ns, row, start_col, {
@@ -125,7 +125,7 @@ local function set_highlights(bufnr, seq_map, curr_seq, lines)
 			--- get after first character until the first bracket (alt timeline)
 			local first_bracket_start = line:find("%[", 1, false)
 			if first_bracket_start and #line > 1 then
-				local between_start = 2 -- after the first character
+				local between_start = 2 * 2 -- after the first character
 				local between_end = first_bracket_start - 1
 				local between_str = line:sub(between_start, between_end)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visual alignment and spacing of tree lines and branch icons in the timeline view for better readability.
  - Adjusted annotation text and highlighting to enhance clarity and consistency in the timeline display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->