### PR TITLE
fix(ui.set_highlights): remain actual hl for current text

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,7 @@ vim.api.nvim_set_hl(0, "TimeMachineCurrent", { fg = "#7dcfff", bold = true })
   ---@type {[string]: CtpHighlight}
   local highlights = {
    TimeMachineCurrent = {
-    bg = c_utils.darken(colors.blue, 0.18, colors.base),
-    fg = colors.blue,
-    style = { "bold" },
+    bg = c_utils.darken(colors.blue, 0.18, colors.base)
    },
    TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
    TimeMachineTimelineAlt = { fg = colors.overlay2 },

--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -1,4 +1,4 @@
-*time-machine.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 April 29
+*time-machine.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 April 30
 
 ==============================================================================
 Table of Contents                        *time-machine.nvim-table-of-contents*
@@ -475,9 +475,7 @@ CATPPUCCIN INTEGRATION (AUTHOR CONFIG) ~
       ---@type {[string]: CtpHighlight}
       local highlights = {
        TimeMachineCurrent = {
-        bg = c_utils.darken(colors.blue, 0.18, colors.base),
-        fg = colors.blue,
-        style = { "bold" },
+        bg = c_utils.darken(colors.blue, 0.18, colors.base)
        },
        TimeMachineTimeline = { fg = colors.blue, style = { "bold" } },
        TimeMachineTimelineAlt = { fg = colors.overlay2 },

--- a/lua/time-machine/config.lua
+++ b/lua/time-machine/config.lua
@@ -57,7 +57,7 @@ function M.setup_highlights()
 	local groups = constants.hl
 
 	local defaults_colors = {
-		current = { bg = "#3c3836", fg = "#fabd2f", bold = true },
+		current = { bg = "#3c3836" },
 		timeline = { fg = "#fabd2f", bold = true },
 		timeline_alt = { fg = "#939AB7" },
 		keymap = { fg = "#8bd5ca", italic = true },

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -111,7 +111,7 @@ local function set_highlights(bufnr, seq_map, curr_seq, lines)
 		end
 
 		--- is within sequence
-		if type(id) == "number" and id ~= curr_seq then
+		if type(id) == "number" then
 			--- get the first character (current timeline)
 			local first_char = line:sub(1 * 2, 1 * 2)
 			if first_char and first_char ~= "" then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated highlight group styling by removing foreground color and bold attributes, retaining only background color for the current entry.
- **Documentation**
  - Refreshed configuration examples and last updated date to reflect styling changes in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->