### PR TITLE
fix(ui): abort opening panel when no undos found

### DIFF
--- a/doc/time-machine.nvim.txt
+++ b/doc/time-machine.nvim.txt
@@ -1,4 +1,4 @@
-*time-machine.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 April 30
+*time-machine.nvim.txt*      For Neovim >= 0.11.0     Last change: 2025 May 04
 
 ==============================================================================
 Table of Contents                        *time-machine.nvim-table-of-contents*

--- a/lua/time-machine/ui.lua
+++ b/lua/time-machine/ui.lua
@@ -388,6 +388,12 @@ function M.show_tree(ut, content_bufnr)
 	local seq_map = {}
 	local tree_lines =
 		tree.build_tree_lines(ut, seq_map, tags, is_current_timeline_toggled)
+
+	if #tree_lines == 0 then
+		vim.notify("No undos yet", vim.log.levels.WARN)
+		return
+	end
+
 	local lines = {}
 
 	for _, line in ipairs(tree_lines) do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a warning message when there is no undo history available, preventing the undo tree UI from opening with empty data.

- **Documentation**
  - Updated the last change date in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->